### PR TITLE
chore: turned lambda runtime into variable

### DIFF
--- a/inputs.tf
+++ b/inputs.tf
@@ -25,3 +25,15 @@ variable "name_suffix" {
   type        = string
   default     = ""
 }
+
+variable "python_runtime" {
+  type        = string
+  description = "Python version used for lambda function"
+  nullable    = false
+  default = "python3.7"
+
+  validation {
+    condition     = can(regex("^python", var.python_runtime))
+    error_message = "Invalid value for variable: python_runtime it must be a python runtime."
+  }
+}

--- a/lambda.tf
+++ b/lambda.tf
@@ -12,7 +12,7 @@ resource "aws_lambda_function" "sftp" {
   function_name    = "${var.name_prefix}-sftp-transfer-server-custom-idp-lambda${var.name_suffix}"
   role             = aws_iam_role.sftp_lambda_role.arn
   handler          = "sftp_lambda.lambda_handler"
-  runtime          = "python3.7"
+  runtime          = var.python_runtime
   source_code_hash = filebase64sha256(data.archive_file.sftp_lambda.output_path)
 
   tracing_config {


### PR DESCRIPTION
AWS lambdas have end of support for Python 3.7 in Nov 27. This update leaves it as the default so shouldn't break current deployments but allows for upgrades. 