### PR TITLE
fix: Correct Cloudwatch loggroup ARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ To create any user to connect to this AWS Transfer server, use [this other modul
 | [aws_api_gateway_resource.users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_resource) | resource |
 | [aws_api_gateway_rest_api.sftp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_rest_api) | resource |
 | [aws_api_gateway_stage.prod](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_stage) | resource |
+| [aws_cloudwatch_log_group.custom_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_role.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.sftp_lambda_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.sftp_transfer_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -55,11 +56,15 @@ To create any user to connect to this AWS Transfer server, use [this other modul
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_custom_log_group"></a> [custom\_log\_group](#input\_custom\_log\_group) | Bool to determine if a customer cloudwatch log group is used | `bool` | `false` | no |
+| <a name="input_custom_log_group_name"></a> [custom\_log\_group\_name](#input\_custom\_log\_group\_name) | String to use as a custom log group name | `string` | `""` | no |
 | <a name="input_input_tags"></a> [input\_tags](#input\_input\_tags) | Map of tags to apply to resources | `map(string)` | `{}` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | String to use as prefix on object names | `string` | n/a | yes |
 | <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix) | String to append to object names. This is optional, so start with dash if using | `string` | `""` | no |
+| <a name="input_python_runtime"></a> [python\_runtime](#input\_python\_runtime) | Python version used for lambda function | `string` | `"python3.7"` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_secrets_prefix"></a> [secrets\_prefix](#input\_secrets\_prefix) | Prefix used to create AWS Secrets | `string` | `"SFTP"` | no |
+| <a name="input_xray_enabled"></a> [xray\_enabled](#input\_xray\_enabled) | Bool to determine if Xray tracing is enabled | `bool` | `false` | no |
 
 ## Outputs
 

--- a/apigateway.tf
+++ b/apigateway.tf
@@ -225,7 +225,7 @@ EOF
 
 resource "aws_cloudwatch_log_group" "custom_log_group" {
   count = var.custom_log_group ? 1 : 0
-  name = var.custom_log_group_name
+  name  = var.custom_log_group_name
 
   tags = var.input_tags
 }

--- a/inputs.tf
+++ b/inputs.tf
@@ -37,3 +37,21 @@ variable "python_runtime" {
     error_message = "Invalid value for variable: python_runtime it must be a python runtime."
   }
 }
+
+variable "xray_enabled" {
+  description = "Bool to determine if Xray tracing is enabled"
+  type        = bool
+  default     = false
+}
+
+variable "custom_log_group" {
+  description = "Bool to determine if a customer cloudwatch log group is used"
+  type        = bool
+  default     = false
+}
+
+variable "custom_log_group_name" {
+  description = "String to use as a custom log group name"
+  type        = string
+  default     = ""
+}

--- a/inputs.tf
+++ b/inputs.tf
@@ -30,7 +30,7 @@ variable "python_runtime" {
   type        = string
   description = "Python version used for lambda function"
   nullable    = false
-  default = "python3.7"
+  default     = "python3.7"
 
   validation {
     condition     = can(regex("^python", var.python_runtime))


### PR DESCRIPTION
## Change description
- Added support for custom cloudwatch log group for APIGateway
- Added variable for XRay
- Fixed reference pointing to CloudWatch Role ARN instead of Log Group ARN (if custom log group used)
- Updated TF Docs

> Description here
The fixes the issue where the CloudWatch role ARN was used in place of the log group ARN. As no log group is created, i've added support to create a custom log group. I have also set XRay to be a variable for those that do not use Xray tracing, and updated the TF docs to match.

## Type of change
- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#13](https://github.com/StratusGrid/terraform-aws-transfer-server-custom-idp/issues/13) 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
