### PR TITLE
Add support for loggroup ARN's in Transfer Server

### DIFF
--- a/inputs.tf
+++ b/inputs.tf
@@ -62,7 +62,7 @@ variable "apigw_caching_enable" {
   default     = false
 }
 
-variable "server_loggroup_arn" {
+variable "server_loggroup_arns" {
   description = "List of LogGroup arns for Transfer Server"
   type        = list
   default     = []

--- a/inputs.tf
+++ b/inputs.tf
@@ -55,8 +55,15 @@ variable "custom_log_group_name" {
   type        = string
   default     = ""
 }
+
 variable "apigw_caching_enable" {
   description = "Bool to enable the cache in the APIGW"
   type        = bool
   default     = false
+}
+
+variable "server_loggroup_arn" {
+  description = "List of LogGroup arns for Transfer Server"
+  type        = list
+  default     = []
 }

--- a/main.tf
+++ b/main.tf
@@ -110,10 +110,11 @@ POLICY
 }
 
 resource "aws_transfer_server" "sftp_transfer_server" {
-  identity_provider_type = "API_GATEWAY"
-  logging_role           = aws_iam_role.sftp_transfer_server.arn
-  invocation_role        = aws_iam_role.sftp_transfer_server_invocation.arn
-  url                    = aws_api_gateway_stage.prod.invoke_url
+  identity_provider_type      = "API_GATEWAY"
+  logging_role                = aws_iam_role.sftp_transfer_server.arn
+  invocation_role             = aws_iam_role.sftp_transfer_server_invocation.arn
+  url                         = aws_api_gateway_stage.prod.invoke_url
+  structured_log_destinations = var.server_loggroup_arns
 
   tags = merge(
     var.input_tags,


### PR DESCRIPTION
## Change description

Support added for Log Group ARN's for the Transfer server when not using Workflows

## Type of change
- [ ] Bug fix (fixes an issue)
- [ x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
