### PR TITLE
Fixing access issues with KMS and Cloudwatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ To create any user to connect to this AWS Transfer server, use [this other modul
 | [aws_iam_role_policy.sftp_lambda_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.sftp_transfer_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.sftp_transfer_server_invocation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.attach_cloudwatch_log_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.sftp_lambda_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.sto-readonly-role-policy-attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.sftp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.apigw_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_transfer_server.sftp_transfer_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/transfer_server) | resource |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 GitHub: [StratusGrid/terraform-aws-transfer-server-custom-idp](https://github.com/StratusGrid/terraform-aws-transfer-server-custom-idp)
 
-This Terraform module will create a custom identity provider based on AWS Secrets (managed by AWS Secret Manager) for the AWS Transfer Familiy. 
+This Terraform module will create a custom identity provider based on AWS Secrets (managed by AWS Secret Manager) for the AWS Transfer Familiy.
 
 ## Example Usage:
 Create a SFTP server with the custom identity provider.
@@ -58,6 +58,7 @@ To create any user to connect to this AWS Transfer server, use [this other modul
 | [aws_iam_role_policy.sftp_transfer_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.sftp_transfer_server_invocation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.sftp_lambda_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.sto-readonly-role-policy-attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.sftp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.apigw_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_transfer_server.sftp_transfer_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/transfer_server) | resource |
@@ -83,6 +84,7 @@ To create any user to connect to this AWS Transfer server, use [this other modul
 | Name | Description |
 |------|-------------|
 | <a name="output_invoke_url"></a> [invoke\_url](#output\_invoke\_url) | URL used for REST API invovation |
+| <a name="output_lambda_role"></a> [lambda\_role](#output\_lambda\_role) | The name of role the Lambda used to access secrets. Used to add additional permissions as needed. |
 | <a name="output_rest_api_http_method"></a> [rest\_api\_http\_method](#output\_rest\_api\_http\_method) | REST API calling method |
 | <a name="output_rest_api_id"></a> [rest\_api\_id](#output\_rest\_api\_id) | ID of the REST API |
 | <a name="output_rest_api_stage_name"></a> [rest\_api\_stage\_name](#output\_rest\_api\_stage\_name) | Name used for the stage of API |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 GitHub: [StratusGrid/terraform-aws-transfer-server-custom-idp](https://github.com/StratusGrid/terraform-aws-transfer-server-custom-idp)
 
-This Terraform module will create a custom identity provider based on AWS Secrets (managed by AWS Secret Manager) for the AWS Transfer Familiy.
+This Terraform module will create a custom identity provider based on AWS Secrets (managed by AWS Secret Manager) for the AWS Transfer Familiy. 
 
 ## Example Usage:
 Create a SFTP server with the custom identity provider.

--- a/apigateway.tf
+++ b/apigateway.tf
@@ -226,6 +226,15 @@ resource "aws_iam_role_policy" "cloudwatch" {
 EOF
 }
 
+data "aws_iam_policy" "cloudwatch_log_access" {
+  arn = "arn:aws:iam::aws:policy/AmazonAPIGatewayPushToCloudWatchLogs"
+}
+
+resource "aws_iam_role_policy_attachment" "sto-readonly-role-policy-attach" {
+  role       = aws_iam_role.cloudwatch.id
+  policy_arn = data.aws_iam_policy.cloudwatch_log_access.arn
+}
+
 resource "aws_cloudwatch_log_group" "custom_log_group" {
   count = var.custom_log_group ? 1 : 0
   name  = var.custom_log_group_name

--- a/apigateway.tf
+++ b/apigateway.tf
@@ -230,7 +230,7 @@ data "aws_iam_policy" "cloudwatch_log_access" {
   arn = "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
 }
 
-resource "aws_iam_role_policy_attachment" "sto-readonly-role-policy-attach" {
+resource "aws_iam_role_policy_attachment" "attach_cloudwatch_log_access" {
   role       = aws_iam_role.cloudwatch.id
   policy_arn = data.aws_iam_policy.cloudwatch_log_access.arn
 }

--- a/apigateway.tf
+++ b/apigateway.tf
@@ -227,7 +227,7 @@ EOF
 }
 
 data "aws_iam_policy" "cloudwatch_log_access" {
-  arn = "arn:aws:iam::aws:policy/AmazonAPIGatewayPushToCloudWatchLogs"
+  arn = "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
 }
 
 resource "aws_iam_role_policy_attachment" "sto-readonly-role-policy-attach" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,8 @@ output "transfer_server_id" {
   description = "The Server ID of the Transfer Server (e.g., s-12345678)"
   value       = aws_transfer_server.sftp_transfer_server.id
 }
+
+output "lambda_role_arn" {
+  description = "The ARN of role the Lambda used to access secrets. Used to add additional permissions as needed."
+  value       = aws_iam_role.sftp_lambda_role
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,7 @@ output "transfer_server_id" {
   value       = aws_transfer_server.sftp_transfer_server.id
 }
 
-output "lambda_role_arn" {
-  description = "The ARN of role the Lambda used to access secrets. Used to add additional permissions as needed."
-  value       = aws_iam_role.sftp_lambda_role.arn
+output "lambda_role" {
+  description = "The name of role the Lambda used to access secrets. Used to add additional permissions as needed."
+  value       = aws_iam_role.sftp_lambda_role.name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,5 +25,5 @@ output "transfer_server_id" {
 
 output "lambda_role_arn" {
   description = "The ARN of role the Lambda used to access secrets. Used to add additional permissions as needed."
-  value       = aws_iam_role.sftp_lambda_role
+  value       = aws_iam_role.sftp_lambda_role.arn
 }


### PR DESCRIPTION
## Change description

> Attempted to add this fresh and was seeing multiple issues. After tracking them down, there were two main issues:

1. The additional KMS key rotation added in the user module (https://github.com/StratusGrid/terraform-aws-transfer-server-custom-idp-user/blob/618da1e3dd42201c59262eede13aa2714ca34dc2/main.tf#L38) will cause errors in the Lambda. The key policy alone is insufficient for access. 
2. The Cloudwatch configuration gives errors under some circumstances. I was able to apply this successfully in some environments without it, but for CR prod and staging, it required this additional cloudwatch access, or else it simply hangs when applying.

To fix this, I have exposed the lambda ARN here so that the user module can attach the KMS access as needed. I debated doing the inverse dependency (sending the KMS keys to this module instead) but this seemed more easily extensible.


## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
